### PR TITLE
Add per-location timezone support for date series queries

### DIFF
--- a/src/HeatKeeper.Server.Database/EnergyCosts/GetLocationEnergyCostSettings.sql
+++ b/src/HeatKeeper.Server.Database/EnergyCosts/GetLocationEnergyCostSettings.sql
@@ -1,5 +1,6 @@
 SELECT
     l.SmartMeterSensorId,
-    l.EnergyCalculationStrategy
+    l.EnergyCalculationStrategy,
+    l.TimeZone
 FROM Locations l
 WHERE l.Id = @LocationId

--- a/src/HeatKeeper.Server.Database/Locations/GetLocationDetails.sql
+++ b/src/HeatKeeper.Server.Database/Locations/GetLocationDetails.sql
@@ -11,6 +11,7 @@ SELECT
     l.UseFixedEnergyPrice,
     l.EnergyPriceAreaId,
     l.SmartMeterSensorId,
-    l.EnergyCalculationStrategy
+    l.EnergyCalculationStrategy,
+    l.TimeZone
 FROM Locations l
 WHERE l.id = @id

--- a/src/HeatKeeper.Server.Database/Locations/GetTimeZoneByZoneId.sql
+++ b/src/HeatKeeper.Server.Database/Locations/GetTimeZoneByZoneId.sql
@@ -1,0 +1,4 @@
+SELECT COALESCE(l.TimeZone, '') AS TimeZone
+FROM Locations l
+INNER JOIN Zones z ON z.LocationId = l.Id
+WHERE z.Id = @ZoneId

--- a/src/HeatKeeper.Server.Database/Locations/InsertLocation.sql
+++ b/src/HeatKeeper.Server.Database/Locations/InsertLocation.sql
@@ -1,2 +1,2 @@
-INSERT INTO Locations (Name, Description, Longitude, Latitude)
-VALUES (@name, @description, @longitude, @latitude)
+INSERT INTO Locations (Name, Description, Longitude, Latitude, TimeZone)
+VALUES (@name, @description, @longitude, @latitude, @TimeZone)

--- a/src/HeatKeeper.Server.Database/Locations/UpdateLocation.sql
+++ b/src/HeatKeeper.Server.Database/Locations/UpdateLocation.sql
@@ -10,6 +10,7 @@ SET
     useFixedEnergyPrice = @useFixedEnergyPrice,
     energyPriceAreaId = @energyPriceAreaId,
     smartMeterSensorId = @smartMeterSensorId,
-    energyCalculationStrategy = @energyCalculationStrategy
+    energyCalculationStrategy = @energyCalculationStrategy,
+    timeZone = @TimeZone
 WHERE
     id = @Id

--- a/src/HeatKeeper.Server.Database/Migrations/Version24/AddTimeZoneToLocationsTable.cs
+++ b/src/HeatKeeper.Server.Database/Migrations/Version24/AddTimeZoneToLocationsTable.cs
@@ -1,0 +1,14 @@
+using System.Data;
+using DbReader;
+using HeatKeeper.Server.Database.Migrations;
+
+namespace HeatKeeper.Server.Database.Migrations.Version24;
+
+[AppliesToVersion(24, Order = 1)]
+public class AddTimeZoneToLocationsTable(ISqlProvider sqlProvider) : IMigration
+{
+    public void Migrate(IDbConnection dbConnection)
+    {
+        dbConnection.Execute(sqlProvider.AddTimeZoneToLocationsTable);
+    }
+}

--- a/src/HeatKeeper.Server.Database/Migrations/Version24/AddTimeZoneToLocationsTable.sql
+++ b/src/HeatKeeper.Server.Database/Migrations/Version24/AddTimeZoneToLocationsTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Locations ADD COLUMN TimeZone TEXT

--- a/src/HeatKeeper.Server.Database/Migrations/Version24/SetDefaultTimeZoneForAllLocations.cs
+++ b/src/HeatKeeper.Server.Database/Migrations/Version24/SetDefaultTimeZoneForAllLocations.cs
@@ -1,0 +1,14 @@
+using System.Data;
+using DbReader;
+using HeatKeeper.Server.Database.Migrations;
+
+namespace HeatKeeper.Server.Database.Migrations.Version24;
+
+[AppliesToVersion(24, Order = 2)]
+public class SetDefaultTimeZoneForAllLocations(ISqlProvider sqlProvider) : IMigration
+{
+    public void Migrate(IDbConnection dbConnection)
+    {
+        dbConnection.Execute(sqlProvider.SetDefaultTimeZoneForAllLocations);
+    }
+}

--- a/src/HeatKeeper.Server.Database/Migrations/Version24/SetDefaultTimeZoneForAllLocations.sql
+++ b/src/HeatKeeper.Server.Database/Migrations/Version24/SetDefaultTimeZoneForAllLocations.sql
@@ -1,0 +1,1 @@
+UPDATE Locations SET TimeZone = 'Europe/Oslo'

--- a/src/HeatKeeper.Server.Database/Sql.cs
+++ b/src/HeatKeeper.Server.Database/Sql.cs
@@ -434,4 +434,8 @@ public interface ISqlProvider
     string DeleteLatestSensorMeasurements { get; }
 
     string GetEnergyConsumers { get; }
+
+    string AddTimeZoneToLocationsTable { get; }
+
+    string GetTimeZoneByZoneId { get; }
 }

--- a/src/HeatKeeper.Server.Database/Sql.cs
+++ b/src/HeatKeeper.Server.Database/Sql.cs
@@ -437,5 +437,7 @@ public interface ISqlProvider
 
     string AddTimeZoneToLocationsTable { get; }
 
+    string SetDefaultTimeZoneForAllLocations { get; }
+
     string GetTimeZoneByZoneId { get; }
 }

--- a/src/HeatKeeper.Server.WebApi.Tests/HttpClientExtensions.cs
+++ b/src/HeatKeeper.Server.WebApi.Tests/HttpClientExtensions.cs
@@ -12,6 +12,8 @@ using CQRS.Query.Abstractions;
 using FluentAssertions;
 using HeatKeeper.Server.Authentication;
 using HeatKeeper.Server.Dashboard;
+using HeatKeeper.Server.TimeZones;
+using TimeZoneInfo = HeatKeeper.Server.TimeZones.TimeZoneInfo;
 using HeatKeeper.Server.EnergyPriceAreas;
 using HeatKeeper.Server.EnergyPriceAreas.Api;
 using HeatKeeper.Server.EnergyPrices.Api;
@@ -315,6 +317,9 @@ namespace HeatKeeper.Server.WebApi.Tests
 
         public static async Task<LocationInfo[]> GetLocations(this HttpClient client, string token, Action<HttpResponseMessage> success = null, Action<ProblemDetails> problem = null)
             => await Get<LocationInfo[]>(client, "api/locations", token, success, problem);
+
+        public static async Task<TimeZoneInfo[]> GetTimeZones(this HttpClient client, string token, Action<HttpResponseMessage> success = null, Action<ProblemDetails> problem = null)
+            => await Get<TimeZoneInfo[]>(client, "api/time-zones", token, success, problem);
 
         private static async Task<TContent> Get<TContent>(HttpClient client, string uri, string token, Action<HttpResponseMessage> success = null, Action<ProblemDetails> problem = null)
         {

--- a/src/HeatKeeper.Server.WebApi.Tests/TimeZonesTests.cs
+++ b/src/HeatKeeper.Server.WebApi.Tests/TimeZonesTests.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using HeatKeeper.Server.TimeZones;
+using Xunit;
+
+namespace HeatKeeper.Server.WebApi.Tests;
+
+public class TimeZonesTests : TestBase
+{
+    [Fact]
+    public async Task ShouldReturnTimeZones()
+    {
+        var client = Factory.CreateClient();
+        var token = await client.AuthenticateAsAdminUser();
+
+        var timeZones = await client.GetTimeZones(token);
+
+        timeZones.Should().NotBeEmpty();
+        timeZones.Should().Contain(tz => tz.Id == "Europe/Oslo");
+    }
+}

--- a/src/HeatKeeper.Server/EnergyCosts/Api/GetEnergyCosts.cs
+++ b/src/HeatKeeper.Server/EnergyCosts/Api/GetEnergyCosts.cs
@@ -10,22 +10,22 @@ public record EnergyCost(Resolution Resolution, EnergyCostEntry[] TimeSeries);
 
 public record EnergyCostEntry(DateTime Timestamp, double PowerImport, decimal CostInLocalCurrency, decimal CostInLocalCurrencyAfterSubsidy, decimal CostInLocalCurrencyWithFixedPrice);
 
-internal record LocationEnergyCostSettings(long? SmartMeterSensorId, EnergyCalculationStrategy EnergyCalculationStrategy);
+internal record LocationEnergyCostSettings(long? SmartMeterSensorId, EnergyCalculationStrategy EnergyCalculationStrategy, string TimeZone = null);
 
 public class GetEnergyCostsQueryHandler(IDbConnection dbConnection, ISqlProvider sqlProvider, TimeProvider timeProvider) : IQueryHandler<GetEnergyCostsQuery, EnergyCost>
 {
     public async Task<EnergyCost> HandleAsync(GetEnergyCostsQuery query, CancellationToken cancellationToken = default)
     {
+        var settings = (await dbConnection.ReadAsync<LocationEnergyCostSettings>(
+            sqlProvider.GetLocationEnergyCostSettings,
+            new { query.LocationId })).SingleOrDefault();
+
         var now = timeProvider.GetUtcNow().UtcDateTime;
-        var (fromDateTime, toDateTime) = TimePeriodCalculator.GetDateRange(query.TimePeriod, now);
+        var (fromDateTime, toDateTime) = TimePeriodCalculator.GetDateRange(query.TimePeriod, now, settings?.TimeZone);
         var resolution = TimePeriodCalculator.GetResolution(query.TimePeriod);
 
         if (query.SensorId.HasValue)
             return new EnergyCost(resolution, await QueryBySensor(query.SensorId.Value, fromDateTime, toDateTime, resolution));
-
-        var settings = (await dbConnection.ReadAsync<LocationEnergyCostSettings>(
-            sqlProvider.GetLocationEnergyCostSettings,
-            new { query.LocationId })).SingleOrDefault();
 
         if (settings?.EnergyCalculationStrategy == EnergyCalculationStrategy.SmartMeter)
         {

--- a/src/HeatKeeper.Server/EnergyCosts/Api/GetEnergyCostsPerZone.cs
+++ b/src/HeatKeeper.Server/EnergyCosts/Api/GetEnergyCostsPerZone.cs
@@ -7,8 +7,9 @@ public class GetEnergyCostsPerZoneQueryHandler(IDbConnection dbConnection, ISqlP
 {
     public async Task<EnergyCost> HandleAsync(EnergyCostsPerZoneQuery query, CancellationToken cancellationToken = default)
     {
+        var timeZoneId = (await dbConnection.ReadAsync<string?>(sqlProvider.GetTimeZoneByZoneId, new { query.ZoneId })).SingleOrDefault();
         var now = timeProvider.GetUtcNow().UtcDateTime;
-        var (fromDateTime, toDateTime) = TimePeriodCalculator.GetDateRange(query.TimePeriod, now);
+        var (fromDateTime, toDateTime) = TimePeriodCalculator.GetDateRange(query.TimePeriod, now, timeZoneId);
         var resolution = TimePeriodCalculator.GetResolution(query.TimePeriod);
 
         var sql = resolution switch

--- a/src/HeatKeeper.Server/EnergyCosts/TimePeriodCalculator.cs
+++ b/src/HeatKeeper.Server/EnergyCosts/TimePeriodCalculator.cs
@@ -18,6 +18,38 @@ public static class TimePeriodCalculator
             _ => throw new ArgumentOutOfRangeException(nameof(timePeriod))
         };
 
+    public static (DateTime from, DateTime to) GetDateRange(TimePeriod timePeriod, DateTime utcNow, string timezoneId)
+    {
+        if (string.IsNullOrEmpty(timezoneId))
+            return GetDateRange(timePeriod, utcNow);
+
+        TimeZoneInfo timezone;
+        try { timezone = TimeZoneInfo.FindSystemTimeZoneById(timezoneId); }
+        catch { return GetDateRange(timePeriod, utcNow); }
+
+        var localNow = TimeZoneInfo.ConvertTimeFromUtc(utcNow, timezone);
+        var (localFrom, localTo) = GetLocalDateRange(timePeriod, localNow);
+
+        return (
+            TimeZoneInfo.ConvertTimeToUtc(localFrom, timezone),
+            TimeZoneInfo.ConvertTimeToUtc(localTo, timezone)
+        );
+    }
+
+    private static (DateTime from, DateTime to) GetLocalDateRange(TimePeriod timePeriod, DateTime localNow)
+        => timePeriod switch
+        {
+            TimePeriod.Today => (localNow.Date, localNow),
+            TimePeriod.Yesterday => (localNow.Date.AddDays(-1), localNow.Date),
+            TimePeriod.LastWeek => (localNow.Date.AddDays(-(((int)localNow.DayOfWeek + 6) % 7) - 7), localNow.Date.AddDays(-(((int)localNow.DayOfWeek + 6) % 7))),
+            TimePeriod.ThisWeek => (localNow.Date.AddDays(-(((int)localNow.DayOfWeek + 6) % 7)), localNow),
+            TimePeriod.ThisMonth => (new DateTime(localNow.Year, localNow.Month, 1), localNow),
+            TimePeriod.LastMonth => (new DateTime(localNow.Year, localNow.Month, 1).AddMonths(-1), new DateTime(localNow.Year, localNow.Month, 1)),
+            TimePeriod.ThisYear => (new DateTime(localNow.Year, 1, 1), localNow),
+            TimePeriod.LastYear => (new DateTime(localNow.Year - 1, 1, 1), new DateTime(localNow.Year, 1, 1)),
+            _ => throw new ArgumentOutOfRangeException(nameof(timePeriod))
+        };
+
     public static Resolution GetResolution(TimePeriod timePeriod)
         => timePeriod switch
         {

--- a/src/HeatKeeper.Server/Locations/Api/CreateLocation.cs
+++ b/src/HeatKeeper.Server/Locations/Api/CreateLocation.cs
@@ -2,7 +2,7 @@ namespace HeatKeeper.Server.Locations;
 
 [RequireAdminRole]
 [Post("api/locations")]
-public record CreateLocationCommand(string Name, string Description, double? Latitude, double? Longitude) : PostCommand;
+public record CreateLocationCommand(string Name, string Description, double? Latitude, double? Longitude, string TimeZone = null) : PostCommand;
 
 public class CreateLocation(IDbConnection dbConnection, ISqlProvider sqlProvider) : ICommandHandler<CreateLocationCommand>
 {

--- a/src/HeatKeeper.Server/Locations/Api/GetLocationDetails.cs
+++ b/src/HeatKeeper.Server/Locations/Api/GetLocationDetails.cs
@@ -4,7 +4,7 @@ namespace HeatKeeper.Server.Locations.Api;
 [Get("api/locations/{locationId}")]
 public record GetLocationDetailsQuery(long LocationId) : IQuery<LocationDetails>;
 
-public record LocationDetails(long Id, string Name, string Description, long? DefaultOutsideZoneId, long? DefaultInsideZoneId, long? ActiveProgramId, double? Longitude, double? Latitude, double FixedEnergyPrice, bool UseFixedEnergyPrice, long? EnergyPriceAreaId, long? SmartMeterSensorId, EnergyCalculationStrategy EnergyCalculationStrategy);
+public record LocationDetails(long Id, string Name, string Description, long? DefaultOutsideZoneId, long? DefaultInsideZoneId, long? ActiveProgramId, double? Longitude, double? Latitude, double FixedEnergyPrice, bool UseFixedEnergyPrice, long? EnergyPriceAreaId, long? SmartMeterSensorId, EnergyCalculationStrategy EnergyCalculationStrategy, string TimeZone = null);
 
 public class GetLocationDetails(IDbConnection dbConnection, ISqlProvider sqlProvider) : IQueryHandler<GetLocationDetailsQuery, LocationDetails>
 {

--- a/src/HeatKeeper.Server/Locations/Api/UpdateLocation.cs
+++ b/src/HeatKeeper.Server/Locations/Api/UpdateLocation.cs
@@ -2,7 +2,7 @@ namespace HeatKeeper.Server.Locations.Api;
 
 [RequireAdminRole]
 [Patch("api/locations/{id}")]
-public record UpdateLocationCommand(long Id, string Name, string Description, long? DefaultOutsideZoneId, long? DefaultInsideZoneId, double? Longitude, double? Latitude, double FixedEnergyPrice, bool UseFixedEnergyPrice, long? EnergyPriceAreaId, long? SmartMeterSensorId, EnergyCalculationStrategy EnergyCalculationStrategy) : PatchCommand;
+public record UpdateLocationCommand(long Id, string Name, string Description, long? DefaultOutsideZoneId, long? DefaultInsideZoneId, double? Longitude, double? Latitude, double FixedEnergyPrice, bool UseFixedEnergyPrice, long? EnergyPriceAreaId, long? SmartMeterSensorId, EnergyCalculationStrategy EnergyCalculationStrategy, string TimeZone = null) : PatchCommand;
 
 public class UpdateLocation(IDbConnection dbConnection, ISqlProvider sqlProvider) : ICommandHandler<UpdateLocationCommand>
 {

--- a/src/HeatKeeper.Server/TimeZones/GetTimeZones.cs
+++ b/src/HeatKeeper.Server/TimeZones/GetTimeZones.cs
@@ -1,0 +1,15 @@
+namespace HeatKeeper.Server.TimeZones;
+
+[RequireUserRole]
+[Get("api/time-zones")]
+public record GetTimeZonesQuery : IQuery<TimeZoneInfo[]>;
+
+public record TimeZoneInfo(string Id, string DisplayName);
+
+public class GetTimeZonesQueryHandler : IQueryHandler<GetTimeZonesQuery, TimeZoneInfo[]>
+{
+    public Task<TimeZoneInfo[]> HandleAsync(GetTimeZonesQuery query, CancellationToken cancellationToken = default)
+        => Task.FromResult(System.TimeZoneInfo.GetSystemTimeZones()
+            .Select(tz => new TimeZoneInfo(tz.Id, tz.DisplayName))
+            .ToArray());
+}

--- a/src/HeatKeeper.Server/ZoneTemperatures/GetZoneTemperaturesPerZone.cs
+++ b/src/HeatKeeper.Server/ZoneTemperatures/GetZoneTemperaturesPerZone.cs
@@ -14,8 +14,9 @@ public class GetZoneTemperaturesPerZoneQueryHandler(IDbConnection dbConnection, 
 {
     public async Task<ZoneTemperatureResult> HandleAsync(ZoneTemperaturesPerZoneQuery query, CancellationToken cancellationToken = default)
     {
+        var timeZoneId = (await dbConnection.ReadAsync<string?>(sqlProvider.GetTimeZoneByZoneId, new { query.ZoneId })).SingleOrDefault();
         var now = timeProvider.GetUtcNow().UtcDateTime;
-        var (fromDateTime, toDateTime) = TimePeriodCalculator.GetDateRange(query.TimePeriod, now);
+        var (fromDateTime, toDateTime) = TimePeriodCalculator.GetDateRange(query.TimePeriod, now, timeZoneId);
         var resolution = TimePeriodCalculator.GetResolution(query.TimePeriod);
 
         var sql = resolution switch


### PR DESCRIPTION
## Summary

- Adds a `TimeZone` column (IANA timezone ID, e.g. `Europe/Oslo`) to the `Locations` table via migration Version24, and sets `Europe/Oslo` as the default for all existing locations
- `TimePeriodCalculator` gains a new overload `GetDateRange(timePeriod, utcNow, timezoneId)` that converts UTC now to local time, computes date boundaries (today, this week, this month, etc.) in local time, then converts them back to UTC for DB queries
- `GetEnergyCostsQueryHandler`, `GetEnergyCostsPerZoneQueryHandler`, and `GetZoneTemperaturesPerZoneQueryHandler` all look up the location timezone and pass it through — locations with no timezone set continue to use UTC as before
- Adds `GET api/time-zones` endpoint returning `[{ "id": "...", "displayName": "..." }]` for use in UI select inputs

## Test plan

- [ ] Verify existing locations are migrated to `Europe/Oslo` and energy cost / zone temperature queries for `Today` start at local midnight (23:00 UTC previous day) rather than 00:00 UTC
- [ ] Verify locations with no timezone set are unaffected
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)